### PR TITLE
feat: add directory watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.18.3",
+    "chokidar": "^2.0.4",
     "colors-cli": "^1.0.13",
     "http-proxy": "^1.17.0",
     "path-to-regexp": "^2.2.1"


### PR DESCRIPTION
这里使用了chokidar 监听 watchFile 所在的目录，只要mock的配置文件都在同一个目录，或子目录下。
当文件更新时重载更新的文件和入口文件。